### PR TITLE
[refactor] readme 수정-> 포트 번호 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Gateway가 Keycloak 공개키로 JWT 서명을 검증하고 claims를 직접 파
 
 `docker-compose up -d` 하면 실행됩니다.
 
-Keycloak은 시작까지 약 30~40초 걸립니다 저는 더 짧앗습니다.
+Keycloak은 시작까지 약 30~40초 소요됩니다.
 
 ### 상태 확인
 
@@ -119,8 +119,8 @@ trusta-keycloak           Up (healthy)
 ### Keycloak 관리자 콘솔 접속
 
 ```
-URL      : http://localhost:8080
-아이디   : admin
+URL    : http://localhost:9090
+아이디  : admin
 비밀번호 : admin
 ```
 
@@ -148,7 +148,7 @@ URL      : http://localhost:8080
 
 ```
 Method : POST
-URL    : http://localhost:8080/realms/trusta/protocol/openid-connect/token
+URL    : http://localhost:9090/realms/trusta/protocol/openid-connect/token
 Body   : x-www-form-urlencoded
 
 grant_type    = password
@@ -168,11 +168,13 @@ password      = member123
   "expires_in": 300
 }
 ```
-재발급은 로컬황경에서는 만료될떄마다 토큰을 재발급 받는 방법이 더 간단합니다.
+
+> 로컬 환경에서는 만료될 때마다 토큰을 재발급 받는 방법이 더 간단합니다.
+
 ### curl로 발급
 
 ```bash
-curl -X POST http://localhost:8080/realms/trusta/protocol/openid-connect/token \
+curl -X POST http://localhost:9090/realms/trusta/protocol/openid-connect/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=password" \
   -d "client_id=trusta-gateway" \
@@ -199,25 +201,30 @@ trusta:
 
 ```
 Method  : GET
-URL     : http://localhost:{서비스포트}/users/me
+URL     : http://localhost:{서비스포트}/api/v1/users/me
 Headers :
   X-User-UUID     : 550e8400-e29b-41d4-a716-446655440000
   X-User-Email    : member@trusta.com
   X-User-Role     : ROLE_MEMBER
-  X-User-Nickname : 테스트유저
+  X-User-Name     : 테스트유저
+  X-User-Slack-Id : (선택 — 검수자/관리자 계정만 필요)
   X-User-Enabled  : true
 ```
+
+> ⚠️ `X-User-Enabled` 헤더는 반드시 포함해야 합니다. 누락 시 400 에러가 발생합니다.
 
 ### curl로 테스트
 
 ```bash
-curl -X GET http://localhost:18081/users/me \
+curl -X GET http://localhost:18081/api/v1/users/me \
   -H "X-User-UUID: 550e8400-e29b-41d4-a716-446655440000" \
   -H "X-User-Email: member@trusta.com" \
   -H "X-User-Role: ROLE_MEMBER" \
-  -H "X-User-Nickname: 테스트유저" \
+  -H "X-User-Name: %ED%85%8C%EC%8A%A4%ED%8A%B8%EC%9C%A0%EC%A0%80" \
   -H "X-User-Enabled: true"
 ```
+
+> curl 사용 시 한글 이름은 URL 인코딩이 필요합니다. Postman 사용을 권장합니다.
 
 ---
 
@@ -225,13 +232,17 @@ curl -X GET http://localhost:18081/users/me \
 
 Gateway가 Keycloak 공개키로 JWT 서명 검증 후 claims를 파싱해서 각 서비스로 전달하는 헤더 목록입니다.
 
-| 헤더명          | 설명                       | 예시                                 |
-|-----------------|----------------------------|--------------------------------------|
-| X-User-UUID     | 유저 식별자 (Keycloak sub) | 550e8400-e29b-41d4-a716-446655440000 |
-| X-User-Email    | 로그인 이메일              | member@trusta.com                    |
-| X-User-Role     | Spring Security 권한       | ROLE_MEMBER                          |
-| X-User-Nickname | 닉네임                     | 테스트유저                            |
-| X-User-Enabled  | 계정 활성화 여부           | true                                 |
+| 헤더명          | 필수 여부 | 설명                       | 예시                                 |
+|-----------------|-----------|----------------------------|--------------------------------------|
+| X-User-UUID     | 필수      | 유저 식별자 (Keycloak sub) | 550e8400-e29b-41d4-a716-446655440000 |
+| X-User-Email    | 필수      | 로그인 이메일              | member@trusta.com                    |
+| X-User-Role     | 필수      | Spring Security 권한       | ROLE_MEMBER                          |
+| X-User-Name     | 선택      | 유저 이름 (URL 인코딩)     | %ED%99%8D%EA%B8%B8%EB%8F%99          |
+| X-User-Slack-Id | 선택      | 슬랙 ID (검수자/관리자용)  | U12345678                            |
+| X-User-Enabled  | 필수      | 계정 활성화 여부           | true                                 |
+
+> ⚠️ Gateway는 `X-User-Name` 헤더에 한글이 포함된 경우 반드시 **URL 인코딩**해서 전달해야 합니다.
+> common의 `LoginFilter`가 수신 시 자동으로 URL 디코딩합니다.
 
 ---
 
@@ -245,7 +256,7 @@ Gateway가 Keycloak 공개키로 JWT 서명 검증 후 claims를 파싱해서 �
 implementation 'com.trustamarket:common:0.0.1-SNAPSHOT'
 ```
 
-### 2. application.yml 설정 추가
+### 2. application-local.yml 설정 추가
 
 ```yaml
 trusta:
@@ -253,8 +264,34 @@ trusta:
     trust-gateway-headers: true
 ```
 
-> common 모듈의 LoginFilter가 X-User-* 헤더를 자동으로 SecurityContext에 주입합니다.
+> common 모듈의 `LoginFilter`가 X-User-* 헤더를 자동으로 `SecurityContext`에 주입합니다.
 > 각 서비스는 JWT나 Keycloak을 직접 알 필요가 없습니다.
+
+### 3. SecurityUtil로 현재 사용자 조회
+
+```java
+// 현재 로그인한 사용자 UUID 조회 (없으면 401)
+UUID currentUserId = SecurityUtil.getCurrentUserIdOrThrow();
+
+// 현재 로그인한 사용자 전체 정보 조회
+Optional<UserDetailsImpl> currentUser = SecurityUtil.getCurrentUser();
+```
+
+---
+
+## api-gateway application.yml 설정
+
+```yaml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:9090/realms/trusta
+```
+
+> `issuer-uri`를 설정하면 Spring이 자동으로 공개키 엔드포인트를 찾아갑니다.
+> 공개키 엔드포인트: `http://localhost:9090/realms/trusta/protocol/openid-connect/certs`
 
 ---
 
@@ -265,6 +302,7 @@ trusta:
 | Realm 이름    | trusta                        |
 | Client ID     | trusta-gateway                |
 | Client Secret | gateway-secret-change-in-prod |
+| Keycloak 포트 | 9090                          |
 | Access Token  | 5분                           |
 | Refresh Token | 30분                          |
 
@@ -328,7 +366,7 @@ docker-compose down -v
 docker-compose up -d
 ```
 
-> `-v` 옵션은 볼륨(DB 데이터)도 삭제합니다. 로컬 개발 데이터가 초기화됩니다.
+> ⚠️ `-v` 옵션은 볼륨(DB 데이터)도 삭제합니다. 로컬 개발 데이터가 초기화됩니다.
 
 ---
 
@@ -337,10 +375,21 @@ docker-compose up -d
 Keycloak 관리자 콘솔에서 Client Secret을 확인하세요.
 
 ```
-http://localhost:8080
+http://localhost:9090
 → trusta Realm 선택
 → Clients → trusta-gateway → Credentials 탭
 → Client Secret 값 확인
+```
+
+---
+
+### X-User-Enabled 누락으로 400 오류가 날 때
+
+Gateway 없이 단독 테스트 시 `X-User-Enabled` 헤더를 빠뜨리면 발생합니다.
+
+```
+Headers에 반드시 추가
+X-User-Enabled : true
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       KC_HTTP_ENABLED: true
       TZ: Asia/Seoul
     ports:
-      - "8080:8080"
+      - "9090:8080"
     volumes:
       - ./docker/keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json
     depends_on:

--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -19,6 +19,47 @@
       "authorizationServicesEnabled": false,
       "redirectUris": [
         "http://localhost:*/*"
+      ],
+      "protocolMappers": [
+        {
+          "name": "enabled-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "enabled",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "enabled",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "name": "slack-id-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "slack_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "slack_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "full-name-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
       ]
     }
   ],
@@ -55,7 +96,10 @@
       ],
       "realmRoles": [
         "ADMIN"
-      ]
+      ],
+      "attributes": {
+        "slack_id": ["U_ADMIN_TEST"]
+      }
     },
     {
       "username": "test-inspector",
@@ -73,7 +117,10 @@
       ],
       "realmRoles": [
         "INSPECTOR"
-      ]
+      ],
+      "attributes": {
+        "slack_id": ["U_INSPECTOR_TEST"]
+      }
     },
     {
       "username": "test-member",


### PR DESCRIPTION
realm - export.json 수정 -> enabled , slackid , full-name Mapper 추가

## 🌱 설명

- keycloak 기본 설정에 enabled claim 이 JWT 에 없어서 안들어감
  - Mapper 추가

## 📌 관련 이슈

close #6 

## ✅ 주요 변경 사항

- readme .md 설명 수정
- realm 수정
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> SecurityConfig public 경로를 보면
```
.pathMatchers("/actuator/**").permitAll()
.anyExchange().authenticated()
```
- 지금은 actuator 만 열려있는데 나중에 상품 조회 같은 비인증 API 가 생기면 여기에 추가해야됩니다
혹시 이미 볼륨이 생성된 상태라면 볼륨 삭제후 재실행해야 Mapper 가 적용됩니다
```
docker-compose down -v
docker-compose up -d
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Keycloak admin console migrated to port 9090
  * Authentication tokens now include enabled status, Slack ID, and full name user attributes

* **Documentation**
  * Updated service configuration examples and API endpoint information
  * Enhanced authentication header requirements documentation with troubleshooting guidance for common setup issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->