### PR TITLE
chore: GKE 배포 설정 추가 (keycloak + postgres)

### DIFF
--- a/.github/workflows/deploy-keycloak.yml
+++ b/.github/workflows/deploy-keycloak.yml
@@ -1,0 +1,46 @@
+name: Deploy Keycloak
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - k8s/keycloak/**
+      - .github/workflows/deploy-keycloak.yml
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/37902116541/locations/global/workloadIdentityPools/trusta-pool-github/providers/trusta-provider-github
+          service_account: trusta-sa-github-deployer@trusta-market-id.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: trusta-cluster
+          location: asia-northeast3-a
+
+      - name: Apply Postgres
+        run: kubectl apply -f k8s/keycloak/postgres.yaml
+
+      - name: Wait for Postgres rollout
+        run: kubectl rollout status deployment/keycloak-postgres --timeout=3m
+
+      - name: Apply Keycloak
+        run: kubectl apply -f k8s/keycloak/keycloak.yaml
+
+      - name: Wait for Keycloak rollout
+        run: kubectl rollout status deployment/keycloak --timeout=8m

--- a/k8s/keycloak/keycloak.yaml
+++ b/k8s/keycloak/keycloak.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      # Keycloak 이미지의 jboss 유저 UID 1000.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:24.0.0
+          args: ["start-dev", "--import-realm"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8080
+          env:
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL
+              value: jdbc:postgresql://keycloak-postgres:5432/keycloak_db
+            - name: KC_DB_USERNAME
+              value: keycloak
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-secrets
+                  key: KC_DB_PASSWORD
+            - name: KEYCLOAK_ADMIN
+              value: admin
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-secrets
+                  key: KEYCLOAK_ADMIN_PASSWORD
+            # Keycloak 24 는 health endpoint 기본 비활성 — 명시 활성 필요.
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          volumeMounts:
+            - name: realm
+              mountPath: /opt/keycloak/data/import
+              readOnly: true
+          # startupProbe — 24.0.0 첫 시작 + realm import 시간 변동 큼. 5s × 60 = 300s (5분) 대기.
+          startupProbe:
+            httpGet:
+              path: /health/started
+              port: 8080
+            failureThreshold: 60
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8080
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            periodSeconds: 5
+      volumes:
+        - name: realm
+          configMap:
+            name: keycloak-realm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  type: ClusterIP
+  selector:
+    app: keycloak
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/k8s/keycloak/postgres.yaml
+++ b/k8s/keycloak/postgres.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keycloak-postgres-pvc
+  labels:
+    app: keycloak-postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-postgres
+  labels:
+    app: keycloak-postgres
+spec:
+  replicas: 1
+  # RWO PVC — replicas 2 이상 불가 (단일 노드만 mount 가능). 후속에 Cloud SQL 마이그레이션 시점에 HA 검토.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: keycloak-postgres
+  template:
+    metadata:
+      labels:
+        app: keycloak-postgres
+    spec:
+      # postgres 이미지 안의 postgres 유저 UID/GID = 999. PVC 마운트된 디렉토리의 group 권한을 999 로 맞춰 쓰기 가능하게.
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: keycloak
+            - name: POSTGRES_DB
+              value: keycloak_db
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-secrets
+                  key: KC_DB_PASSWORD
+            # PVC 안에 PGDATA 가 root 로 박혀있으면 권한 충돌 → 별도 subdir 로 격리.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "keycloak", "-d", "keycloak_db"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "keycloak", "-d", "keycloak_db"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: keycloak-postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgres
+  labels:
+    app: keycloak-postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: keycloak-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP


### PR DESCRIPTION
## 🌱 설명

Keycloak + Keycloak 전용 PostgreSQL 을 GKE 에 배포. 로컬 docker-compose 의 두 서비스 (`keycloak`, `keycloak-postgres`) 를 K8s Deployment 두 개 + PVC + Service 로 옮김.

Spring Boot 빌드 X (공식 이미지 사용). 매니페스트만 `trusta-local-infra/k8s/keycloak/` 에 추가.

## 📌 관련 이슈

해당 없음 (인프라 셋업, 이슈 생략)

## ✅ 주요 변경 사항

- `k8s/keycloak/postgres.yaml` (신규)
  - PVC `keycloak-postgres-pvc` (5Gi, `standard-rwo`)
  - Deployment `keycloak-postgres` (postgres:17-alpine, replicas 1, `Recreate` 전략 — RWO PVC 제약), `securityContext.fsGroup: 999` (postgres 유저)
  - `PGDATA: /var/lib/postgresql/data/pgdata` (PVC 안 subdir — 권한 충돌 회피)
  - Service `keycloak-postgres` ClusterIP port 5432
- `k8s/keycloak/keycloak.yaml` (신규)
  - Deployment `keycloak` (quay.io/keycloak/keycloak:24.0.0, replicas 1)
  - args `["start-dev", "--import-realm"]`
  - env: DB 연결 + Admin 자격증명 (둘 다 Secret `keycloak-secrets` 에서 주입), `KC_HEALTH_ENABLED=true` (★ 24 는 기본 비활성), `KC_HOSTNAME_STRICT=false`
  - ConfigMap `keycloak-realm` 을 `/opt/keycloak/data/import` 에 readOnly mount
  - Pod/Container securityContext (runAsNonRoot, runAsUser 1000, capabilities.drop:[ALL])
  - startupProbe 5분 대기 (24.0.0 첫 부팅 + realm import), liveness `/health/live`, readiness `/health/ready` (port 8080)
  - Service `keycloak` ClusterIP port 80 → 8080
- `.github/workflows/deploy-keycloak.yml` (신규)
  - develop push + workflow_dispatch
  - paths 필터로 `k8s/keycloak/**` 변경 시에만 트리거
  - WIF 인증 → get-gke-credentials → kubectl apply (postgres → 대기 → keycloak)

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요? *(인프라 셋업이라 이슈 생략)*
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?

## 🔧 머지 전 필수 — 수동 사전 작업

K8s Secret + ConfigMap 미리 만들어야 Pod 가 뜸. PR 머지 = 자동 배포 시작이라 그 전에 실행:

```bash
# 1. Secret 생성 (DB/Admin 비밀번호 — 배포 환경 강한 값, 로컬 docker-compose 와 다르게)
kubectl create secret generic keycloak-secrets \
  --from-literal=KC_DB_PASSWORD='<강한 DB 비밀번호>' \
  --from-literal=KEYCLOAK_ADMIN_PASSWORD='<강한 admin 비밀번호>'

# 2. ConfigMap 생성 (realm import 정의)
kubectl create configmap keycloak-realm \
  --from-file=realm-export.json=docker/keycloak/realm-export.json

# 확인
kubectl get secret keycloak-secrets
kubectl get configmap keycloak-realm
```

⚠ 배포 환경 비밀번호는 로컬 docker-compose 의 `keycloak_pw` / `admin` 과 다르게 생성. 팀에 공유 시 onetimesecret 또는 1Password 권장. `realm-export.json` 안의 client secret `gateway-secret-change-in-prod` 도 운영 진입 시 변경 필요.

## 🧪 검증 절차

```bash
kubectl get pods -l app=keycloak-postgres -o wide          # 1/1 Running
kubectl get pvc keycloak-postgres-pvc                       # Bound
kubectl get pods -l app=keycloak -o wide                    # 1/1 Running (3~5분)
kubectl logs deployment/keycloak --tail=200 | grep -i realm # "Imported realm trusta"

kubectl port-forward svc/keycloak 8080:80                   # 로컬 접속
# → http://localhost:8080/admin (admin / admin)
# → Master realm → 드롭다운 → trusta realm 선택 → clients 에 trusta-gateway 존재 확인
```

## 📚 추가 설명 / 후속

- **start-dev 모드** — TLS/HTTPS 강제 안 되고, 일부 기능 자동 활성. 운영 진입 시 `start` 모드 + `KC_HOSTNAME` 설정 + Ingress + ManagedCertificate 필요 (PRD §9-#11)
- **24 → 26 마이그레이션** — 후속. major 업그레이드라 realm export/import 검증 필요
- **PostgreSQL K8s 내장 → Cloud SQL** — 후속 (PRD §9-#10). 백업·HA·운영 부담 줄임
- **PVC RWO 제약** — replicas 1 고정. Cloud SQL 마이그레이션 시 자연스럽게 해결
- **dev 비밀번호 회전** — 운영 전 필수. Secret 갱신 + Deployment 재시작 (`kubectl rollout restart deployment/keycloak`)
- **client secret `gateway-secret-change-in-prod`** — `realm-export.json` 박혀있음. 운영 전 변경 + gateway 의 application-k8s.yml 동시 갱신
