### PR TITLE
chore: GKE 도메인 공유 PostgreSQL 추가

### DIFF
--- a/k8s/keycloak/postgres.yaml
+++ b/k8s/keycloak/postgres.yaml
@@ -63,14 +63,15 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+          # Probe — POSTGRES_USER 는 Secret 회전 시 변경될 수 있으므로 env 참조.
           livenessProbe:
             exec:
-              command: ["pg_isready", "-U", "keycloak", "-d", "keycloak_db"]
+              command: ["sh", "-c", 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"']
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             exec:
-              command: ["pg_isready", "-U", "keycloak", "-d", "keycloak_db"]
+              command: ["sh", "-c", 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"']
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:

--- a/k8s/postgres/postgres.yaml
+++ b/k8s/postgres/postgres.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  labels:
+    app: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  # RWO PVC 라 단일 노드만 mount → replicas 2 이상 불가. Cloud SQL 마이그레이션 시 HA 검토.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      # postgres 이미지의 postgres 유저 UID/GID = 999.
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_USERNAME
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_PASSWORD
+            - name: POSTGRES_DB
+              value: trusta_market
+            # PVC 안 별도 subdir 로 격리 (권한 충돌 회피)
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "trusta_admin", "-d", "trusta_market"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "trusta_admin", "-d", "trusta_market"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP

--- a/k8s/postgres/postgres.yaml
+++ b/k8s/postgres/postgres.yaml
@@ -66,14 +66,15 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+          # Probe — POSTGRES_USER 는 Secret 에서 주입되므로 env 참조 (회전 시 매니페스트 같이 안 건드리게).
           livenessProbe:
             exec:
-              command: ["pg_isready", "-U", "trusta_admin", "-d", "trusta_market"]
+              command: ["sh", "-c", 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"']
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             exec:
-              command: ["pg_isready", "-U", "trusta_admin", "-d", "trusta_market"]
+              command: ["sh", "-c", 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"']
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:


### PR DESCRIPTION
## 🌱 설명

도메인 서비스 공유 PostgreSQL 을 GKE 에 배포. 모든 도메인 서비스 (user/order/...) 가 단일 `postgres` Service 를 통해 접근. keycloak-postgres 와 분리.

Cloud SQL 마이그레이션은 후속 (PRD §9-#10) — 일단 K8s 내장 + PVC 로 빠른 진행.

## 📌 관련 이슈

해당 없음 (인프라 셋업, 이슈 생략)

## ✅ 주요 변경 사항

- `k8s/postgres/postgres.yaml` (신규)
  - PVC `postgres-pvc` (10Gi, `standard-rwo`)
  - Deployment `postgres` (postgres:17-alpine, replicas 1, `Recreate` 전략), `fsGroup: 999`
  - `POSTGRES_DB=trusta_market` (도메인 공유 단일 DB, 서비스별 schema 분리는 후속)
  - `POSTGRES_USER` / `POSTGRES_PASSWORD` 를 Secret `domain-postgres-secrets` 에서 주입
  - `PGDATA: /var/lib/postgresql/data/pgdata` (PVC subdir)
  - Service `postgres` ClusterIP port 5432

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요? *(인프라 셋업이라 이슈 생략)*
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?

## 🔧 머지 전 필수 — 수동 Secret 생성

```bash
kubectl create secret generic domain-postgres-secrets \
  --from-literal=DB_USERNAME='trusta_admin' \
  --from-literal=DB_PASSWORD='trusta_six_sense_7531%'

kubectl get secret domain-postgres-secrets   # DATA 2 확인
```

## 🧪 검증 절차

```bash
kubectl get pods -l app=postgres -o wide      # 1/1 Running
kubectl get pvc postgres-pvc                  # Bound
kubectl logs deployment/postgres --tail=50    # database system is ready 메시지
```

## 📚 추가 설명 / 후속

- **단일 DB + schema 분리 (PRD §3-2)**: 현재는 schema 미적용 (default public). 도메인 서비스 코드 변경 필요해서 후속 PR. 일단 한 DB 안에서 entity 들이 public schema 에 생성.
- **Cloud SQL 마이그레이션**: PRD §9-#10. 부하 테스트 후 마이그레이션 검토.
- **RWO PVC 제약**: replicas 1 고정. HA / 스케일 아웃 필요해지면 Cloud SQL.
- **백업**: 현재 X. 운영 진입 시 PVC snapshot 또는 Cloud SQL backup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * PostgreSQL 17 database deployment infrastructure added with 10GB persistent storage, automated health monitoring via liveness and readiness probes, CPU and memory resource allocation with limits, security context configuration, and Kubernetes secret-based credential management. Database service exposed on port 5432.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/trusta-local-infra/pull/13)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->